### PR TITLE
Fix wrong deprecation annotation

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/PlayerUpdateBuilder.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/PlayerUpdateBuilder.kt
@@ -128,7 +128,7 @@ class PlayerUpdateBuilder internal constructor(private val node: LavalinkNode, p
 
     @Deprecated(
         message = "This method causes improper usage of the reactor system",
-        replaceWith = ReplaceWith("subscribe()")
+        replaceWith = ReplaceWith("this")
     )
     fun asMono(): Mono<LavalinkPlayer>  = this
 


### PR DESCRIPTION
Currently, the ReplaceWith annotation tells IntelliJ to replace with `subscribe()`, which is not correct, since this will replace with subscribe().subscribe() in most cases, or even worse destroy things like asMono().map().subscribe(), replacing it with this, will tell the IDE to use the instance of PlayerUpdateBuilder as a Mono like it is intended
