### PR TITLE
Update voice region filters to match subregions. 

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/loadbalancing/regionFiltering.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/loadbalancing/regionFiltering.kt
@@ -80,7 +80,7 @@ object RegionGroup {
 
 // TODO In case no exact server match, should it look for the closest node in that same region?
 enum class VoiceRegion(val id: String, val subregions: HashSet<String>, val visibleName: String) {
-    BRAZIL("brazil", hashSetOf("buenos-aires"), "Brazil"),
+    BRAZIL("brazil", hashSetOf("buenos-aires", "santiago"), "Brazil"),
     HONGKONG("hongkong", hashSetOf(), "Hong Kong"),
     INDIA("india", hashSetOf(), "India"),
     JAPAN("japan", hashSetOf("south-korea"),"Japan"),

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/loadbalancing/regionFiltering.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/loadbalancing/regionFiltering.kt
@@ -23,7 +23,7 @@ enum class RegionFilterVerdict {
 object RegionGroup {
     @JvmField
     val ASIA: IRegionFilter = object : IRegionFilter {
-        val regions = listOf(VoiceRegion.SYDNEY, VoiceRegion.INDIA, VoiceRegion.JAPAN, VoiceRegion.HONGKONG, VoiceRegion.SINGAPORE)
+        val regions = listOf(VoiceRegion.SYDNEY, VoiceRegion.INDIA, VoiceRegion.JAPAN, VoiceRegion.HONGKONG, VoiceRegion.SINGAPORE, VoiceRegion.SOUTH_KOREA)
 
         override fun isRegionAllowed(node: LavalinkNode, region: VoiceRegion): RegionFilterVerdict {
             return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
@@ -31,7 +31,8 @@ object RegionGroup {
     }
     @JvmField
     val EUROPE: IRegionFilter = object : IRegionFilter {
-        val regions = listOf(VoiceRegion.ROTTERDAM, VoiceRegion.RUSSIA)
+        val regions = listOf(VoiceRegion.ROTTERDAM, VoiceRegion.RUSSIA, VoiceRegion.AMSTERDAM, VoiceRegion.MADRID, VoiceRegion.MILAN,
+            VoiceRegion.BUCHAREST, VoiceRegion.EUROPE, VoiceRegion.LONDON, VoiceRegion.FINLAND, VoiceRegion.FRANKFURT, VoiceRegion.STOCKHOLM)
 
         override fun isRegionAllowed(node: LavalinkNode, region: VoiceRegion): RegionFilterVerdict {
             return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
@@ -39,7 +40,8 @@ object RegionGroup {
     }
     @JvmField
     val US: IRegionFilter = object : IRegionFilter {
-        val regions = listOf(VoiceRegion.US_CENTRAL, VoiceRegion.US_EAST, VoiceRegion.US_SOUTH, VoiceRegion.US_WEST)
+        val regions = listOf(VoiceRegion.US_CENTRAL, VoiceRegion.US_EAST, VoiceRegion.US_SOUTH, VoiceRegion.US_WEST, VoiceRegion.ATLANTA,
+            VoiceRegion.SEATTLE, VoiceRegion.SANTA_CLARA, VoiceRegion.NEWARK, VoiceRegion.MONTREAL, VoiceRegion.OREGON, VoiceRegion.ST_PETE)
 
         override fun isRegionAllowed(node: LavalinkNode, region: VoiceRegion): RegionFilterVerdict {
             return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
@@ -47,7 +49,7 @@ object RegionGroup {
     }
     @JvmField
     val SOUTH_AMERICA: IRegionFilter = object : IRegionFilter {
-        val regions = listOf(VoiceRegion.BRAZIL)
+        val regions = listOf(VoiceRegion.BRAZIL, VoiceRegion.SANTIAGO, VoiceRegion.BUENOS_AIRES)
 
         override fun isRegionAllowed(node: LavalinkNode, region: VoiceRegion): RegionFilterVerdict {
             return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
@@ -61,57 +63,84 @@ object RegionGroup {
             return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
         }
     }
+    @JvmField
+    val MIDDLE_EAST: IRegionFilter = object : IRegionFilter {
+        val regions = listOf(VoiceRegion.TEL_AVIV, VoiceRegion.DUBAI)
+
+        override fun isRegionAllowed(node: LavalinkNode, region: VoiceRegion): RegionFilterVerdict {
+            return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
+        }
+    }
 
 
     /**
      * Gets a [RegionGroup] from a string. This method is case-insensitive.
      *
-     * @param region The region to get the [RegionGroup] for. Valid values are [ASIA], [EUROPE], and [US].
+     * @param region The region to get the [RegionGroup] for.
+     * Valid values are [AFRICA], [ASIA], [EUROPE], [MIDDLE_EAST], [SOUTH_AMERICA] and [US].
      */
     fun valueOf(region: String) = when (region.uppercase()) {
+        "AFRICA" -> AFRICA
         "ASIA" -> ASIA
         "EUROPE" -> EUROPE
-        "US" -> US
+        "MIDDLE_EAST" -> MIDDLE_EAST
         "SOUTH_AMERICA" -> SOUTH_AMERICA
-        "AFRICA" -> AFRICA
+        "US" -> US
         else -> throw IllegalArgumentException("No region constant: $region")
     }
 }
 
 // TODO In case no exact server match, should it look for the closest node in that same region?
-enum class VoiceRegion(val id: String, val subregions: HashSet<String>, val visibleName: String) {
-    BRAZIL("brazil", hashSetOf("buenos-aires", "santiago"), "Brazil"),
-    HONGKONG("hongkong", hashSetOf(), "Hong Kong"),
-    INDIA("india", hashSetOf(), "India"),
-    JAPAN("japan", hashSetOf("south-korea"),"Japan"),
-    ROTTERDAM("rotterdam", hashSetOf("frankfurt", "stockholm", "bucharest", "milan", "madrid"),"Rotterdam"),
-    RUSSIA("russia", hashSetOf(),"Russia"),
-    SINGAPORE("singapore", hashSetOf(),"Singapore"),
-    SOUTH_AFRICA("southafrica", hashSetOf("dubai", "tel-aviv"),"South Africa"),
-    SYDNEY("sydney", hashSetOf(), "Sydney"),
-    US_CENTRAL("us-central", hashSetOf(), "US Central"),
-    US_EAST("us-east", hashSetOf("newark"), "US East"),
-    US_SOUTH("us-south", hashSetOf("atlanta"), "US South"),
-    US_WEST("us-west", hashSetOf("seattle", "santa-clara"), "US West"),
+enum class VoiceRegion(val id: String, val visibleName: String) {
+    AMSTERDAM("amsterdam", "Amsterdam"),
+    ATLANTA("atlanta", "Atlanta"),
+    BRAZIL("brazil", "Brazil"),
+    BUCHAREST("bucharest", "Bucharest"),
+    BUENOS_AIRES("buenos-aires", "Brazil"),
+    DUBAI("dubai", "Dubai"),
+    EUROPE("europe", "Europe"),
+    FINLAND("finland", "Finland"),
+    FRANKFURT("frankfurt", "Frankfurt"),
+    HONGKONG("hongkong", "Hong Kong"),
+    INDIA("india", "India"),
+    JAPAN("japan","Japan"),
+    LONDON("london", "London"),
+    MADRID("madrid", "Madrid"),
+    MILAN("milan", "Milan"),
+    MONTREAL("montreal", "Montreal"),
+    NEWARK("newark", "Newark"),
+    OREGON("oregon", "Oregon"),
+    ROTTERDAM("rotterdam","Rotterdam"),
+    RUSSIA("russia", "Russia"),
+    SANTA_CLARA("santa-clara", "Santa Clara"),
+    SANTIAGO("santiago", "Santiago"),
+    SEATTLE("seattle", "Seattle"),
+    SINGAPORE("singapore", "Singapore"),
+    SOUTH_AFRICA("southafrica","South Africa"),
+    SOUTH_KOREA("south-korea", "South Korea"),
+    ST_PETE("st-pete", "St Pete"),
+    STOCKHOLM("stockholm", "Stockholm"),
+    SYDNEY("sydney", "Sydney"),
+    TEL_AVIV("tel-aviv", "Tel Aviv"),
+    US_CENTRAL("us-central", "US Central"),
+    US_EAST("us-east", "US East"),
+    US_SOUTH("us-south", "US South"),
+    US_WEST("us-west", "US West"),
 
-    UNKNOWN("", hashSetOf(), "Unknown");
+    UNKNOWN("", "Unknown");
 
     companion object {
         @JvmStatic
         fun fromEndpoint(endpoint: String): VoiceRegion {
             // Endpoints come in format like "seattle1865.discord.gg", trim to subdomain with no numbers
-            val trimmedEndpoint =  endpoint.split(".")[0].filter { !it.isDigit() }
-
-            for(region in VoiceRegion.values()) {
-                if (trimmedEndpoint == region.id || region.subregions.contains(trimmedEndpoint)) {
-                    return region
-                }
-            }
-            return UNKNOWN
+            val endpointRegex = "^([a-z\\-]+)[0-9]+.*:443\$".toRegex()
+            val match = endpointRegex.find(endpoint) ?: return UNKNOWN
+            val idFromEndpoint = match.groupValues[1]
+            return entries.find { it.id == idFromEndpoint } ?: UNKNOWN
         }
     }
 
     override fun toString(): String {
-        return "${name}($id, $visibleName, subregions: ${subregions.toArray()})"
+        return "${name}($id, $visibleName)"
     }
 }


### PR DESCRIPTION
I was noticing a large amount of voice region match failures resulting in UNKNOWN region usage. Discord is pretty opaque about all of the voice endpoints outside of the ones shown in UI. There appear to be a large amount of subregions within the UI select able regions. These updates will make the default voice region load balancer take those subregions into account. 

## Changes:
- Update voice region to contain a set of subregions
- Add region groups for Africa and South america to allow for better regionality
- Fix typo in Sydney region (Would be a breaking change for anyone referencing the misspelled enum) 

I am leaving this WIP for a while as I keep collecting a list of subregions, so far I have seen: 
![](https://snipboard.io/jMq6DW.jpg)