### PR TITLE
Add http timeout configuration for nodes

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -5,6 +5,7 @@ import dev.arbjerg.lavalink.client.loadbalancing.IRegionFilter
 import dev.arbjerg.lavalink.client.loadbalancing.VoiceRegion
 import dev.arbjerg.lavalink.client.loadbalancing.builtin.DefaultLoadBalancer
 import dev.arbjerg.lavalink.internal.ReconnectTask
+import dev.arbjerg.lavalink.internal.TIMEOUT_MS
 import dev.arbjerg.lavalink.protocol.v4.Message
 import reactor.core.Disposable
 import reactor.core.publisher.Flux
@@ -62,12 +63,12 @@ class LavalinkClient(val userId: Long) : Closeable, Disposable {
      * @param regionFilter (not currently used) Allows you to limit your node to a specific discord voice region
      */
     @JvmOverloads
-    fun addNode(name: String, address: URI, password: String, regionFilter: IRegionFilter? = null): LavalinkNode {
+    fun addNode(name: String, address: URI, password: String, regionFilter: IRegionFilter? = null, httpTimeout: Long = TIMEOUT_MS): LavalinkNode {
         if (nodes.any { it.name == name }) {
             throw IllegalStateException("Node with name '$name' already exists")
         }
 
-        val node = LavalinkNode(name, address, password, regionFilter, this)
+        val node = LavalinkNode(name, address, password, regionFilter, httpTimeout, this)
         internalNodes.add(node)
 
         listenForNodeEvent(node)

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -30,6 +30,7 @@ import java.io.Closeable
 import java.io.IOException
 import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 import java.util.function.UnaryOperator
 
@@ -41,6 +42,7 @@ class LavalinkNode(
     serverUri: URI,
     val password: String,
     val regionFilter: IRegionFilter?,
+    private val httpTimeout: Long,
     val lavalink: LavalinkClient
 ) : Disposable, Closeable {
     // "safe" uri with all paths removed
@@ -49,7 +51,7 @@ class LavalinkNode(
     var sessionId: String? = null
         internal set
 
-    internal val httpClient = OkHttpClient()
+    internal val httpClient = OkHttpClient().newBuilder().callTimeout(httpTimeout, TimeUnit.MILLISECONDS).build()
 
     internal val sink: Many<ClientEvent<*>> = Sinks.many().multicast().onBackpressureBuffer()
     val flux: Flux<ClientEvent<*>> = sink.asFlux()

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/constants.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/constants.kt
@@ -1,4 +1,4 @@
 package dev.arbjerg.lavalink.internal
 
-internal const val TIMEOUT_MS = 5000
+internal const val TIMEOUT_MS = 10000L
 internal const val METRIC_MAX_HISTORY = 100


### PR DESCRIPTION
Currently nodes only use the default HTTP timeouts set by OKHTTP, which are: 
- Connect: 10sec
- Read: 10sec
- Write: 10sec
- Call: No timeout

This PR allows the consumer to set an optional total call timeout. It utilizes the currently unused constant TIMEOUT_MS and changes that to a default of 10sec per request. 10 seconds was chosen to avoid moving the timeout up too much from what it is now, 10 sec to connect, 10 more sec to finish read/write op. I doubt many users have latency > 5s but it avoids someone from getting a regression if they do. 