### PR TITLE
Make the load balancer immediately aware of the number of playing players

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/loadbalancing/Penalties.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/loadbalancing/Penalties.kt
@@ -61,7 +61,7 @@ data class Penalties(val node: LavalinkNode) {
         // The way we calculate penalties is heavily based on the original Lavalink client.
 
         // This will serve as a rule of thumb. 1 playing player = 1 penalty point
-        val playerPenalty = stats.playingPlayers
+        val playerPenalty = node.playerCache.count { it.value.track != null && !it.value.paused }
 
         val cpuPenalty = (1.05.pow(100 * stats.cpu.systemLoad) * 10 - 10).toInt()
 

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/loadbalancing/Penalties.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/loadbalancing/Penalties.kt
@@ -3,6 +3,7 @@ package dev.arbjerg.lavalink.internal.loadbalancing
 import dev.arbjerg.lavalink.client.LavalinkNode
 import dev.arbjerg.lavalink.client.loadbalancing.MAX_ERROR
 import dev.arbjerg.lavalink.protocol.v4.Message
+import kotlin.math.max
 import kotlin.math.pow
 
 // Clearing them on a timer sucks, here's some ideas from freya:
@@ -61,7 +62,8 @@ data class Penalties(val node: LavalinkNode) {
         // The way we calculate penalties is heavily based on the original Lavalink client.
 
         // This will serve as a rule of thumb. 1 playing player = 1 penalty point
-        val playerPenalty = node.playerCache.count { it.value.track != null && !it.value.paused }
+        val cachedPlayingPlayers = node.playerCache.count { it.value.track != null && !it.value.paused }
+        val playerPenalty = max(cachedPlayingPlayers, stats.playingPlayers)
 
         val cpuPenalty = (1.05.pow(100 * stats.cpu.systemLoad) * 10 - 10).toInt()
 


### PR DESCRIPTION
This makes the load balancer more responsive to quick increases in player count, as it will not rely on outdated player data.

The current behavior leads to a sawtooth-esque patterns, like seen with this one node:

![image](https://github.com/lavalink-devs/lavalink-client/assets/2582617/fc8e51ef-6110-44f9-83a0-1908b15a548f)


The original V1 client used this: https://github.com/freyacodes/Lavalink-Client/blob/master/src/main/java/lavalink/client/io/LavalinkLoadBalancer.java#L112

I have not tested this code yet.