### PR TITLE
Add resuming options

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -44,7 +44,7 @@ class LavalinkNode(
     val regionFilter = nodeOptions.regionFilter
     val password = nodeOptions.password
 
-    var sessionId: String? = null
+    var sessionId: String? = nodeOptions.sessionId
         internal set
 
     internal val httpClient = OkHttpClient.Builder().callTimeout(nodeOptions.httpTimeout, TimeUnit.MILLISECONDS).build()

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -25,6 +25,7 @@ import reactor.core.publisher.Sinks.Many
 import reactor.kotlin.core.publisher.toMono
 import java.io.Closeable
 import java.io.IOException
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
@@ -232,6 +233,22 @@ class LavalinkNode(
         if (!available) return Mono.error(IllegalStateException("Node is not available"))
 
         return rest.getNodeInfo()
+    }
+
+    /**
+     * Enables resuming. This causes Lavalink to continue playing for a certain duration of time, during which
+     *  we can reconnect without losing our session data. */
+    fun enableResuming(timeout: Duration): Mono<Session> {
+        return rest.patchSession(Session(resuming = true, timeout.seconds))
+    }
+
+    /**
+     * Disables resuming, causing Lavalink to immediately drop all players upon this client disconnecting from it.
+     *
+     * This is the default behavior, reversing calls to [enableResuming].
+     */
+    fun disableResuming(): Mono<Session> {
+        return rest.patchSession(Session(resuming = false, timeoutSeconds = 0))
     }
 
     /**

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -236,7 +236,7 @@ class LavalinkNode(
     }
 
     /**
-     * Enables resuming. This causes Lavalink to continue playing for a certain duration of time, during which
+     * Enables resuming. This causes Lavalink to continue playing for [duration], during which
      *  we can reconnect without losing our session data. */
     fun enableResuming(timeout: Duration): Mono<Session> {
         return rest.patchSession(Session(resuming = true, timeout.seconds))

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/NodeOptions.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/NodeOptions.kt
@@ -8,13 +8,15 @@ data class NodeOptions private constructor(val name: String,
                        val serverUri: URI,
                        val password: String,
                        val regionFilter: IRegionFilter?,
-                       val httpTimeout: Long) {
+                       val httpTimeout: Long,
+                       val sessionId: String?) {
     data class Builder(
         private var name: String? = null,
         private var serverUri: URI? = null,
         private var password: String? = null,
         private var regionFilter: IRegionFilter? = null,
         private var httpTimeout: Long = TIMEOUT_MS,
+        private var sessionId: String? = null
     ) {
         fun setName(name: String) = apply { this.name = name }
 
@@ -53,6 +55,14 @@ data class NodeOptions private constructor(val name: String,
          */
         fun setHttpTimeout(httpTimeout: Long) = apply { this.httpTimeout = httpTimeout }
 
+        /**
+         * Sets the session ID that the client will use when first connecting to Lavalink. If the given session is still
+         *   running on the Lavalink server, the session will be resumed.
+         *
+         * Defaults to null, which means no attempt to resume will be made.
+         */
+        fun setSessionId(sessionId: String?) = apply { this.sessionId = sessionId }
+
         fun build(): NodeOptions {
             requireNotNull(name) { "name is required" }
             requireNotNull(serverUri) { "serverUri is required" }
@@ -63,7 +73,8 @@ data class NodeOptions private constructor(val name: String,
                 serverUri!!,
                 password!!,
                 regionFilter,
-                httpTimeout)
+                httpTimeout,
+                sessionId)
         }
     }
 }

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkRestClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkRestClient.kt
@@ -69,6 +69,13 @@ class LavalinkRestClient(val node: LavalinkNode) {
         }.toMono()
     }
 
+    fun patchSession(session: Session): Mono<Session> {
+        return newRequest {
+            path("/v4/sessions/${node.sessionId}")
+            patch(json.encodeToString(session).toRequestBody("application/json".toMediaType()))
+        }.toMono()
+    }
+
     /**
      * Make a request to the lavalink node. This is internal to keep it looking nice in kotlin. Java compatibility is in the node class.
      */


### PR DESCRIPTION
Adds the ability to control whether Lavalink should try to resume the connection. Also adds the ability to define a session ID from a previous client connection.

This has not been tested yet, hence the draft status