### PR TITLE
Rework resuming

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -9,7 +9,6 @@ import dev.arbjerg.lavalink.internal.ReconnectTask
 import dev.arbjerg.lavalink.protocol.v4.VoiceState
 import reactor.core.Disposable
 import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
 import java.io.Closeable
 import java.time.Duration
@@ -172,13 +171,15 @@ class LavalinkClient(val userId: Long) : Closeable, Disposable {
 
         val session = node.cachedSession
         val canResume = session != null && session.resuming && session.timeoutSeconds > 0
-        if (!canResume) {
-            // If canResume is true, onNodeFirstReconnectFailed(node) may do the transfer
+        if (canResume) {
+            // This causes onResumeReconnectFailed(node) to be called if the next reconnect fails
+            node.ws.onResumableConnectionDisconnected()
+        } else {
             transferNodes(node)
         }
     }
 
-    internal fun onNodeFirstReconnectFailed(node: LavalinkNode) {
+    internal fun onResumeReconnectFailed(node: LavalinkNode) {
         transferNodes(node)
     }
 

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -187,8 +187,6 @@ class LavalinkClient(val userId: Long) : Closeable, Disposable {
         linkMap.forEach { (_, link) ->
             if (link.node == node) {
                 val voiceRegion = link.cachedPlayer?.voiceRegion
-
-                link.state = LinkState.CONNECTING
                 // The delay is used to prevent a race condition in Discord, causing close code 4006
                 link.transferNode(loadBalancer.selectNode(region = voiceRegion, link.guildId), delay = Duration.ofMillis(1000))
             }

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -110,6 +110,19 @@ class LavalinkClient(val userId: Long) : Closeable, Disposable {
             Link(guildId, loadBalancer.selectNode(region, guildId))
         }
     }
+    /**
+     * Get or crate a [Link] between a guild and a node.
+     *
+     * The requested [LavalinkNode] is only assigned if a new [Link] is created
+     *
+     * @param guildId The id of the guild
+     * @param node the node to initially assign the [Link] to if a new one is created
+     */
+    internal fun getOrCreateLink(guildId: Long, node: LavalinkNode): Link {
+        return linkMap.getOrPut(guildId) {
+            Link(guildId, node)
+        }
+    }
 
     /**
      * Returns a [Link] if it exists in the cache.

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -59,7 +59,6 @@ class LavalinkNode(
     internal val sink: Many<ClientEvent> = Sinks.many().multicast().onBackpressureBuffer()
     val flux: Flux<ClientEvent> = sink.asFlux()
     private val reference: Disposable = flux.subscribe()
-    internal var resumeTimer: Disposable? = null
 
     internal val rest = LavalinkRestClient(this)
     val ws = LavalinkSocket(this)

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -54,6 +54,7 @@ class LavalinkNode(
     internal val sink: Many<ClientEvent> = Sinks.many().multicast().onBackpressureBuffer()
     val flux: Flux<ClientEvent> = sink.asFlux()
     private val reference: Disposable = flux.subscribe()
+    internal var resumeTimer: Disposable? = null
 
     internal val rest = LavalinkRestClient(this)
     val ws = LavalinkSocket(this)

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -44,6 +44,7 @@ class LavalinkNode(
     val name = nodeOptions.name
     val regionFilter = nodeOptions.regionFilter
     val password = nodeOptions.password
+    internal var cachedSession: Session? = null
 
     var sessionId: String? = nodeOptions.sessionId
         internal set
@@ -239,7 +240,9 @@ class LavalinkNode(
      * Enables resuming. This causes Lavalink to continue playing for [duration], during which
      *  we can reconnect without losing our session data. */
     fun enableResuming(timeout: Duration): Mono<Session> {
-        return rest.patchSession(Session(resuming = true, timeout.seconds))
+        return rest.patchSession(Session(resuming = true, timeout.seconds)).doOnSuccess {
+            cachedSession = it
+        }
     }
 
     /**
@@ -248,7 +251,9 @@ class LavalinkNode(
      * This is the default behavior, reversing calls to [enableResuming].
      */
     fun disableResuming(): Mono<Session> {
-        return rest.patchSession(Session(resuming = false, timeoutSeconds = 0))
+        return rest.patchSession(Session(resuming = false, timeoutSeconds = 0)).doOnSuccess {
+            cachedSession = it
+        }
     }
 
     /**

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -447,7 +447,7 @@ class LavalinkNode(
             players.forEach { player ->
                 playerCache[player.guildId] = player
 
-                val link = lavalink.getLinkIfCached(player.guildId) ?: return@forEach
+                val link = lavalink.getOrCreateLink(player.guildId, node = this)
                 if (link.node != this) return@forEach
 
                 link.state = if (player.state.connected) {

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -29,6 +29,7 @@ import reactor.util.retry.Retry
 import java.io.Closeable
 import java.io.IOException
 import java.time.Duration
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
@@ -426,6 +427,11 @@ class LavalinkNode(
      * @return The cached player, or null if not yet cached.
      */
     fun getCachedPlayer(guildId: Long): LavalinkPlayer? = playerCache[guildId]
+
+    /**
+     * @return an unmodifiable view of all cached players for this node.
+     */
+    fun getCachedPlayers(): Map<Long, LavalinkPlayer> = Collections.unmodifiableMap(playerCache)
 
     internal fun transferOrphansToSelf() {
         lavalink.transferOrphansTo(this)

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -427,6 +427,8 @@ class LavalinkNode(
      */
     fun getCachedPlayer(guildId: Long): LavalinkPlayer? = playerCache[guildId]
 
+    internal fun getAndRemoveCachedPlayer(guildId: Long): LavalinkPlayer? = playerCache.remove(guildId)
+
     /**
      * @return an unmodifiable view of all cached players for this node.
      */

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/event/events.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/event/events.kt
@@ -7,7 +7,7 @@ import dev.arbjerg.lavalink.client.player.toCustom
 import dev.arbjerg.lavalink.protocol.v4.*
 import dev.arbjerg.lavalink.protocol.v4.Message.EmittedEvent.TrackEndEvent.AudioTrackEndReason
 
-internal fun Message.toClientEvent(node: LavalinkNode) = when (this) {
+internal fun Message.toClientEvent(node: LavalinkNode): ClientEvent = when (this) {
     is Message.ReadyEvent -> ReadyEvent(node, resumed, sessionId)
     is Message.EmittedEvent.TrackEndEvent -> TrackEndEvent(node, guildId.toLong(), track.toCustom(), reason)
     is Message.EmittedEvent.TrackExceptionEvent -> TrackExceptionEvent(node, guildId.toLong(), track.toCustom(), exception.toCustom())
@@ -18,11 +18,18 @@ internal fun Message.toClientEvent(node: LavalinkNode) = when (this) {
     is Message.StatsEvent -> StatsEvent(node, frameStats, players, playingPlayers, uptime, memory, cpu)
 }
 
-sealed class ClientEvent(open val node: LavalinkNode)
+abstract class ClientEvent(open val node: LavalinkNode)
 
 // Normal events
 data class ReadyEvent(override val node: LavalinkNode, val resumed: Boolean, val sessionId: String)
     : ClientEvent(node)
+
+/**
+ * Represents a successful or failed synchronization after a [ReadyEvent] with [ReadyEvent.resumed] set to true.
+ *
+ * Whether it is successful depends on whether [failureReason] is null.
+ */
+data class ResumeSynchronizationEvent(override val node: LavalinkNode, val failureReason: Throwable?) : ClientEvent(node)
 
 data class PlayerUpdateEvent(override val node: LavalinkNode, val guildId: Long, val state: PlayerState)
     : ClientEvent(node)

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkRestClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkRestClient.kt
@@ -76,6 +76,12 @@ class LavalinkRestClient(val node: LavalinkNode) {
         }.toMono()
     }
 
+    fun getSession(): Mono<Session> {
+        return newRequest {
+            path("/v4/sessions/${node.sessionId}")
+        }.toMono()
+    }
+
     /**
      * Make a request to the lavalink node. This is internal to keep it looking nice in kotlin. Java compatibility is in the node class.
      */

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkRestClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkRestClient.kt
@@ -79,6 +79,9 @@ class LavalinkRestClient(val node: LavalinkNode) {
     fun getSession(): Mono<Session> {
         return newRequest {
             path("/v4/sessions/${node.sessionId}")
+            // Using patch with an empty object is a dirty hack because GET is not supported for this resource
+            // 7 years younger me should have known better ~Freya
+            patch("{}".toRequestBody("application/json".toMediaType()))
         }.toMono()
     }
 

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -197,7 +197,11 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
         }
 
         if (hasEverConnected && isAttemptingResume.getAndSet(false)) {
-            node.lavalink.onResumeReconnectFailed(node)
+            try {
+                node.lavalink.onResumeReconnectFailed(node)
+            } catch (e: Exception) {
+                logger.error("Exception after giving up on resuming", e)
+            }
         }
     }
 

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -83,6 +83,8 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
                     node.rest.getSession().subscribe { node.cachedSession = null }
                 }
 
+                node.synchronizeAfterResume()
+
                 // Move players from older, unavailable nodes to ourselves.
                 node.transferOrphansToSelf()
             }

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -75,6 +75,13 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
                         .subscribe()
                 }
 
+                if (!resumed) {
+                    node.cachedSession = null
+                }
+                if (node.cachedSession == null) {
+                    node.rest.getSession().subscribe { node.cachedSession = null }
+                }
+
                 // Move players from older, unavailable nodes to ourselves.
                 node.transferOrphansToSelf()
             }

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -150,9 +150,6 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
         if (mayReconnect) {
             logger.info("${node.name} disconnected, reconnecting in ${reconnectInterval / 1000} seconds")
         }
-
-        node.available = false
-        open = false
     }
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
@@ -200,6 +197,7 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
 
     override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
         node.available = false
+        open = false
         node.lavalink.onNodeDisconnected(node)
 
         if (code == 1000) {

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -40,6 +40,7 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
         logger.info("${node.name} has been connected!")
         open = true
         reconnectsAttempted = 0
+        node.lavalink.onNodeConnected(node)
     }
 
     override fun onMessage(webSocket: WebSocket, text: String) {


### PR DESCRIPTION
This PR includes the following changes:
* Adds caching of the `Session` entity, used by the disconnect code
* If resuming is configured on the server, the client will wait with moving the links to a different node until the first unsuccessful connection attempt
* If a connection is successfully resumed, the client will refresh the player and link state
* Added the new `ResumeSynchronizationEvent` event after refreshing remote state after a resume
* Added `LavalinkNode#getCachedPlayers()`
* Potentially breaking: `ClientEvent` is no longer sealed

Not tested since [8edae46](https://github.com/lavalink-devs/lavalink-client/pull/32/commits/8edae46b9d47bed7335d7af3dc4de3b375d472f2)