### PR TITLE
Custom client name on socket connections

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 /**
  * @param userId ID of the bot for authenticating with Discord
  */
-class LavalinkClient(val userId: Long) : Closeable, Disposable {
+class LavalinkClient(val userId: Long, var clientName: String?) : Closeable, Disposable {
     private val internalNodes = CopyOnWriteArrayList<LavalinkNode>()
     private val linkMap = ConcurrentHashMap<Long, Link>()
     private var clientOpen = true

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit
 
 /**
  * @param userId ID of the bot for authenticating with Discord
+ * @param clientName Name of the client, used for connecting to the Lavalink node(s)
  */
 class LavalinkClient(val userId: Long, var clientName: String?) : Closeable, Disposable {
     private val internalNodes = CopyOnWriteArrayList<LavalinkNode>()
@@ -47,6 +48,11 @@ class LavalinkClient(val userId: Long, var clientName: String?) : Closeable, Dis
     private val reconnectService = Executors.newSingleThreadScheduledExecutor {
         Thread(it, "lavalink-reconnect-thread").apply { isDaemon = true }
     }
+
+    /**
+     * @param userId ID of the bot for authenticating with Discord
+     */
+    constructor(userId: Long) : this(userId, null)
 
     init {
         reconnectService.scheduleWithFixedDelay(ReconnectTask(this), 0, 500, TimeUnit.MILLISECONDS)

--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkNode.kt
@@ -56,7 +56,7 @@ class LavalinkNode(
     private val reference: Disposable = flux.subscribe()
 
     internal val rest = LavalinkRestClient(this)
-    val ws = LavalinkSocket(this)
+    val ws = LavalinkSocket(this, lavalink.clientName)
 
     // Stuff for load balancing
     val penalties = Penalties(this)

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -19,7 +19,8 @@ import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 
-class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Closeable {
+class LavalinkSocket(private val node: LavalinkNode, private val clientName: String?) : WebSocketListener(), Closeable {
+
     private val logger = LoggerFactory.getLogger(LavalinkSocket::class.java)
 
     internal var socket: WebSocket? = null
@@ -221,7 +222,7 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
         val request = Request.Builder()
             .url("${node.baseUri}/v4/websocket")
             .addHeader("Authorization", node.password)
-            .addHeader("Client-Name", "Lavalink-Client/${CLIENT_VERSION}")
+            .addHeader("Client-Name", clientName ?: "Lavalink-Client/${CLIENT_VERSION}")
             .addHeader("User-Id", node.lavalink.userId.toString())
             .apply {
                 if (node.sessionId != null) {

--- a/testbot/src/main/java/me/duncte123/testbot/Main.java
+++ b/testbot/src/main/java/me/duncte123/testbot/Main.java
@@ -23,7 +23,7 @@ public class Main {
 
     public static void main(String[] args) throws InterruptedException {
         final var token = System.getenv("BOT_TOKEN");
-        final LavalinkClient client = new LavalinkClient(Helpers.getUserIdFromToken(token));
+        final LavalinkClient client = new LavalinkClient(Helpers.getUserIdFromToken(token), "TestBot");
 
         client.getLoadBalancer().addPenaltyProvider(new VoiceRegionPenaltyProvider());
 


### PR DESCRIPTION
This pull requests adds support for setting a custom `Client-Name` header when connecting to a Lavalink node.

## Example code
```kt
// Create a LavalinkClient with the default client name (`Lavalink-Client/<VERSION>`)
..
final LavalinkClient client = new LavalinkClient(Helpers.getUserIdFromToken(token));
..

// Create a LavalinkClient with a custom client name
..
final LavalinkClient client = new LavalinkClient(Helpers.getUserIdFromToken(token), "TestBot");
..
```

## Why?
In the case of multiple bots connecting to the same Lavalink node, it can be useful to identify each bot by a name, and not the library that they are using
### Example with the current library
```log
lavalink: 2025-03-05T15:17:25.859Z  INFO 1 --- [Lavalink] [  XNIO-1 task-2] lavalink.server.io.SocketServer          : Connection successfully established from Lavalink-Client/3.2.0
lavalink: 2025-03-05T15:17:26.453Z  INFO 1 --- [Lavalink] [  XNIO-1 task-2] lavalink.server.io.SocketServer          : Connection successfully established from Lavalink-Client/3.2.0
lavalink: 2025-03-05T15:17:27.129Z  INFO 1 --- [Lavalink] [  XNIO-1 task-2] lavalink.server.io.SocketServer          : Connection successfully established from Lavalink-Client/3.2.0
```
### Example with custom client name(s)
```log
lavalink: 2025-03-05T15:17:25.859Z  INFO 1 --- [Lavalink] [  XNIO-1 task-2] lavalink.server.io.SocketServer          : Connection successfully established from TestBot1
lavalink: 2025-03-05T15:17:26.453Z  INFO 1 --- [Lavalink] [  XNIO-1 task-2] lavalink.server.io.SocketServer          : Connection successfully established from TestBot2
lavalink: 2025-03-05T15:17:27.129Z  INFO 1 --- [Lavalink] [  XNIO-1 task-2] lavalink.server.io.SocketServer          : Connection successfully established from TestBot3
```
