### PR TITLE
Add functionality to nodes to transfer all players to other nodes.

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/LavalinkClient.kt
@@ -196,7 +196,7 @@ class LavalinkClient(val userId: Long) : Closeable, Disposable {
         transferNodes(node)
     }
 
-    private fun transferNodes(node: LavalinkNode) {
+    internal fun transferNodes(node: LavalinkNode) {
         linkMap.forEach { (_, link) ->
             if (link.node == node) {
                 val voiceRegion = link.cachedPlayer?.voiceRegion

--- a/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/internal/LavalinkSocket.kt
@@ -66,6 +66,7 @@ class LavalinkSocket(private val node: LavalinkNode) : WebSocketListener(), Clos
 
                 node.sessionId = sessionId
                 node.available = true
+                node.transferring = false
                 logger.info("${node.name} is ready with session id $sessionId")
 
                 node.playerCache.values.forEach { player ->


### PR DESCRIPTION
I was messing around with the new reconnect functionality and was toying with exposing the transferNode function. This allowed for transferring players between nodes. Which can be useful when updating nodes requires a restart of the node. I have a decent sized fleet of nodes and this would be helpful and allow for a much more seamless rollout of updates to my nodes. Allowing users of the client to transfer players away from nodes before rebooting without just killing those players. 
  
One issue I did hit was that the disconnect codes from the node when transferring (and thus disconnecting) would remove the link from cache. We want to preserve that link so I added a state to the node object that prevents the node disconnect codes from removing the transferring links from the cache. This state is removed on a reconnect or manually if desired.  

It may make some sense to add some enum states like the links have with CONNECTED/DISCONNECTED, etc to the node. However, that could be also a bit iffy as a node could be transferring and still connected. So for this change I though the scope or broader implications might be better for a follow through.

#### Changes
- Allowing transferNode fun to be called from internal classes.
- Add transferPlayersToOtherNodes() to the node class that starts a transfer of all players from that node to others. 
- Add a transferring state to the node that prevents disconnect events for the node to remove links from the cache.  