### PR TITLE
Add warsaw region

### DIFF
--- a/src/main/kotlin/dev/arbjerg/lavalink/client/loadbalancing/regionFiltering.kt
+++ b/src/main/kotlin/dev/arbjerg/lavalink/client/loadbalancing/regionFiltering.kt
@@ -40,7 +40,7 @@ object RegionGroup {
     @JvmField
     val EUROPE: IRegionFilter = object : IRegionFilter {
         val regions = listOf(VoiceRegion.ROTTERDAM, VoiceRegion.RUSSIA, VoiceRegion.AMSTERDAM, VoiceRegion.MADRID, VoiceRegion.MILAN,
-            VoiceRegion.BUCHAREST, VoiceRegion.EUROPE, VoiceRegion.LONDON, VoiceRegion.FINLAND, VoiceRegion.FRANKFURT, VoiceRegion.STOCKHOLM)
+            VoiceRegion.BUCHAREST, VoiceRegion.EUROPE, VoiceRegion.LONDON, VoiceRegion.FINLAND, VoiceRegion.FRANKFURT, VoiceRegion.STOCKHOLM, VoiceRegion.WARSAW)
 
         override fun isRegionAllowed(node: LavalinkNode, region: VoiceRegion): RegionFilterVerdict {
             return if (region in regions) RegionFilterVerdict.PASS else RegionFilterVerdict.SOFT_BLOCK
@@ -151,6 +151,7 @@ enum class VoiceRegion(val id: String, val visibleName: String) {
     US_EAST("us-east", "US East"),
     US_SOUTH("us-south", "US South"),
     US_WEST("us-west", "US West"),
+    WARSAW("warsaw", "Warsaw"),
 
     UNKNOWN("", "Unknown");
 


### PR DESCRIPTION
Spotted a new region showing up as unknown. It looks like discord added a warsaw region

![image](https://github.com/user-attachments/assets/d9373467-e779-49b8-a935-125ce995b776)

On a side note as well, Russia has seemingly been removed, makes sense since russia banned discord. But probably doesn't hurt to leave it in there. 

I saw a couple months or so ago pretty much all of my russia traffic moved over to finland
![image](https://github.com/user-attachments/assets/1da16a59-5d40-4793-8ae2-d0561df2c9c5)
